### PR TITLE
Support hyper 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["mime", "multipart", "mixed"]
 
 [dependencies]
-hyper = { version = "0.9", default-features = false }
+hyper = { version = "0.10", default-features = false }
 mime = "0.2"
 httparse = "1.1"
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mime_multipart"
-version = "0.3.5"
+version = "0.4.0"
 description = "MIME multipart parsing, construction, and streaming"
 authors = ["Mike Dilger <mike@optcomp.nz>"]
 readme = "README.md"


### PR DESCRIPTION
This is a breaking change, because hyper is a public dependency. This is why this also bumps the version number to 0.4.