### PR TITLE
Do not send blank line after file part content

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,6 @@ pub fn write_multipart<S: Write>(
                 // Write out the files's content
                 let mut file = try!(File::open(&filepart.path));
                 count += try!(::std::io::copy(&mut file, stream)) as usize;
-                count += try!(stream.write_all_count(b"\r\n"));
             },
             &Node::Multipart((ref headers, ref subnodes)) => {
                 // Get boundary


### PR DESCRIPTION
This is not RFC compliant and actually adds two more bytes to the resulting file. The line break for a new or final delimiter is added line 496.