### PR TITLE
fix generate_boundary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,13 +397,11 @@ fn charset_decode(charset: &Charset, bytes: &[u8]) -> Result<String, Cow<'static
 /// Generate a valid multipart boundary, statistically unlikely to be found within
 /// the content of the parts.
 pub fn generate_boundary() -> Vec<u8> {
-    let mut boundary = TextNonce::sized_urlsafe(68).unwrap().into_string().into_bytes();
-    for b in boundary.iter_mut() {
-		if *b == b'=' {
-			*b = b'x';
-		}
-	};
-    boundary
+    TextNonce::sized(68).unwrap().into_string().into_bytes().iter().map(|&ch| {
+        if ch==b'=' { return b'-'; }
+        else if ch==b'/' { return b'.'; }
+        else { return ch; }
+    }).collect()
 }
 
 // Convenience method, like write_all(), but returns the count of bytes written.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,7 +397,13 @@ fn charset_decode(charset: &Charset, bytes: &[u8]) -> Result<String, Cow<'static
 /// Generate a valid multipart boundary, statistically unlikely to be found within
 /// the content of the parts.
 pub fn generate_boundary() -> Vec<u8> {
-    TextNonce::sized(68).unwrap().into_string().into_bytes()
+    let mut boundary = TextNonce::sized_urlsafe(68).unwrap().into_string().into_bytes();
+    for b in boundary.iter_mut() {
+		if *b == b'=' {
+			*b = b'x';
+		}
+	};
+    boundary
 }
 
 // Convenience method, like write_all(), but returns the count of bytes written.


### PR DESCRIPTION
Replace standard base64 encoding with URL safe version for generating boundary which only consists of alphanumeric US-ASCII characters, underscore and -
Despite = being allowed, many multipart implementations do not quote boundary in Content-Type, so it is safe to remove = from result.